### PR TITLE
Optionally join changes in a buffer for easier :undo.

### DIFF
--- a/doc/quickfix-reflector.txt
+++ b/doc/quickfix-reflector.txt
@@ -59,6 +59,12 @@ this manually, set the value to 0. Default: 1. Example: >
   let g:qf_modifiable=1
 <
 
+                                                              *g:qf_join_changes*
+If 1, changes within a single buffer will be joined using |:undojoin|, allowing
+them to be undone as a unit.  Default: 0. Example: >
+  let g:qf_join_changes = 1
+<
+
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:

--- a/plugin/quickfix-reflector.vim
+++ b/plugin/quickfix-reflector.vim
@@ -6,6 +6,10 @@ if !exists("g:qf_modifiable")
   let g:qf_modifiable=1
 endif
 
+if !exists("g:qf_join_changes")
+  let g:qf_join_changes = 0
+endif
+
 let s:regexpEngine = '\%#=1'
 if v:version < 704
 	let s:regexpEngine = ''
@@ -130,6 +134,7 @@ function! s:Replace(changes)
 	let switchbufOriginal = &switchbuf
 	let &switchbuf = ''
 	let successfulChanges = 0
+	let bufferHasChanged = {}
 	for change in a:changes
 		let bufferWasListed = buflisted(change.qfEntry.bufnr)
 		execute 'tab sbuffer ' . change.qfEntry.bufnr
@@ -141,10 +146,14 @@ function! s:Replace(changes)
 		let commonInQfAndFile_replacement = commonContext.replacement
 		let isUniqueMatchInLine = s:HasSubstringOnce(getline(change.qfEntry.lnum), commonInQfAndFile)
 		if strlen(commonInQfAndFile) >= 3 && isUniqueMatchInLine
+			if g:qf_join_changes && has_key(bufferHasChanged, change.qfEntry.bufnr)
+				undojoin
+			endif
 			execute change.qfEntry.lnum . 'snomagic/\V' . commonInQfAndFile . '/' . commonInQfAndFile_replacement . '/'
 			write
 			let change.qfEntry.text = change.replacementFromQf
 			let successfulChanges += 1
+			let bufferHasChanged[change.qfEntry.bufnr] = 1
 		else
 			let change.qfEntry.text = substitute(change.qfEntry.text, '^\v(\[ERROR\])?', '[ERROR]', '')
 		endif


### PR DESCRIPTION
In order to make it easier to undo mistaken changes within a buffer, Vim's {{:undojoin}} command is optionally used to join multiple changes within each individual buffer.